### PR TITLE
docs(readme): added CSSE couse by practical devsecops

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ None
 
 ## Trainings
 * [cicd-goat](https://github.com/cider-security-research/cicd-goat) - Deliberately vulnerable CI/CD environment. Hack CI/CD pipelines, capture the flags.
+* [Certified Software Supply Chain Security Course](https://www.practical-devsecops.com/certified-software-supply-chain-security-expert/) - CSSE offers comprehensive training on identifying, validating, and mitigating software supply chain risks through hands-on exercises. Covers everything from third-party code to cloud services, aligning with industry frameworks like MITRE ATT&CK and NIST SSDF.
 
 ## Webinars
 * [Endor Labs webinars](https://www.endorlabs.com/resources-overview)


### PR DESCRIPTION
This Merge Request updates the Trainings section in the README.md file by adding information about the Certified Software Supply Chain Security Course.

Changes made:
1. Added a new entry in the Trainings section for the Certified Software Supply Chain Security Course.
2. Included a link to the course's official page.
3. Provided a brief description of the course content and its alignment with industry frameworks.

Updated section in README.md:
## Trainings
* [cicd-goat](https://github.com/cider-security-research/cicd-goat) - Deliberately vulnerable CI/CD environment. Hack CI/CD pipelines, capture the flags.
* [Certified Software Supply Chain Security Course](https://www.practical-devsecops.com/certified-software-supply-chain-security-expert/) - CSSE offers comprehensive training on identifying, validating, and mitigating software supply chain risks through hands-on exercises. Covers everything from third-party code to cloud services, aligning with industry frameworks like MITRE ATT&CK and NIST SSDF.

Motivation:
This addition enhances the value of our repository by providing information about a comprehensive training resource in software supply chain security, which is a critical aspect of AI security.

Related issues: None